### PR TITLE
Skeleton-bg > change animation by using SVGToBase64

### DIFF
--- a/scss/skeleton.scss
+++ b/scss/skeleton.scss
@@ -4,21 +4,6 @@
 @import "helpers";
 
 .skeleton-bg {
-  background-color: #eee;
-  background-image: linear-gradient(
-                  90deg,
-                  rgba(255, 255, 255, 0),
-                  rgba(255, 255, 255, 0.5) 50%,
-                  rgba(255, 255, 255, 0) 80%
-  );
-  background-size: 100px 100%;
-  background-position: -50% 0;
+  background-image: url(data:image/svg+xml;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMTAgMTAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+DQogICAgPGRlZnM+DQogICAgPGxpbmVhckdyYWRpZW50IGlkPSJncmFkIiB4MT0iMCUiIHkxPSIwJSIgeDI9IjEwMCUiIHkyPSIwJSI+DQogICAgICA8c3RvcCBvZmZzZXQ9IjAlIiBzdHlsZT0ic3RvcC1jb2xvcjpyZ2IoMjU1LDI1NSwyNTUpO3N0b3Atb3BhY2l0eTowIiAvPg0KICAgICAgPHN0b3Agb2Zmc2V0PSIxMDAlIiBzdHlsZT0ic3RvcC1jb2xvcjpyZ2IoMjU1LDI1NSwyNTUpO3N0b3Atb3BhY2l0eTowLjgiIC8+DQogICAgPC9saW5lYXJHcmFkaWVudD4NCiAgPC9kZWZzPg0KICAgIDxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIxMCIgaGVpZ2h0PSIxMCIgZmlsbD0iI2VlZSI+PC9yZWN0Pg0KICA8cmVjdCB4PSIwIiB5PSIwIiB3aWR0aD0iMSIgaGVpZ2h0PSIxMCIgZmlsbD0idXJsKCNncmFkKSI+DQogICAgPGFuaW1hdGUNCiAgICAgIGF0dHJpYnV0ZU5hbWU9IngiDQogICAgICB2YWx1ZXM9IjA7MTAiDQogICAgICBkdXI9IjFzIg0KICAgICAgcmVwZWF0Q291bnQ9ImluZGVmaW5pdGUiIC8+DQogIDwvcmVjdD4NCjwvc3ZnPg==);
   background-repeat: repeat-y;
-  animation: skeleton-shine 1.2s infinite;
-}
-
-@keyframes skeleton-shine {
-  to {
-    background-position: 150% 0;
-  }
 }


### PR DESCRIPTION
## Problem
I have removed the animation of `skeleton-bg` (the way we did before) because it causes a conflict on [pagespeed](https://pagespeed.web.dev/), more detail at #19.

## Solution
- Using animation in SVG and adding it to the background image by using [SVG To Base64](https://codebeautify.org/svg-to-base64-converter)
- SVG:
```html
<svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg">
  <defs>
    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="0%">
      <stop offset="0%" style="stop-color:rgb(255,255,255);stop-opacity:0" />
      <stop offset="100%" style="stop-color:rgb(255,255,255);stop-opacity:0.8" />
    </linearGradient>
  </defs>
  <rect x="0" y="0" width="10" height="10" fill="#eee"></rect>
  <rect x="0" y="0" width="1" height="10" fill="url(#grad)">
    <animate
        attributeName="x"
        values="0;10"
        dur="1s"
        repeatCount="indefinite" />
  </rect>
</svg>
```

![ezgif-4-a503dce400](https://user-images.githubusercontent.com/30406982/232690440-1b156b58-ee27-48a3-9167-9dd03d8f65d1.gif)