### PR TITLE
Fix missing loading class

### DIFF
--- a/scss/_build.scss
+++ b/scss/_build.scss
@@ -32,3 +32,4 @@
 @import "extra";
 @import "container";
 @import "font-sizes";
+@import "loading-class";


### PR DESCRIPTION
- Add `@import "loading-class";` into `_build.scss` file

![image](https://github.com/viivue/atomic-css/assets/77733880/2befe6e4-f6ab-4f3f-9b4b-8d2c5a0ecb71)
