### PR TITLE
fix(container): adjust wrong padding value in container fluid

### DIFF
--- a/scss/container.scss
+++ b/scss/container.scss
@@ -50,7 +50,7 @@
 
     @if ($name == 'container-fluid') {
       .#{$name} {
-        @include get-variable(gap-side, format-value($container-gap));
+        @include get-variable(gap-side, var(get-variable(gap-container)));
       }
     } @else {
       .#{$name} {


### PR DESCRIPTION
## Problems
The current value is not responsive.

## Solution
Replace with `--bcnb-gap-container`.

### Before
``` css
.container-fluid {
    --bcnb-gap-side:56px;
}
```

### After
```css
.container-fluid {
    --bb-gap-side:var(--bcnb-gap-container);
}
```
